### PR TITLE
Fix Lean CI with Mathlib setup

### DIFF
--- a/.github/workflows/lean-ci.yml
+++ b/.github/workflows/lean-ci.yml
@@ -44,6 +44,10 @@ jobs:
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
+      - name: 📦 Fetch Lean dependencies
+        working-directory: core/lean
+        run: lake update
+
       - name: 🧪 Run Lean proof build
         working-directory: core/lean
         run: lake build

--- a/core/lean/lakefile.lean
+++ b/core/lean/lakefile.lean
@@ -1,1 +1,11 @@
-// Placeholder for CatPrism/core/lean/lakefile.lean
+import Lake
+open Lake DSL
+
+package CatPrism
+
+require mathlib from git "https://github.com/leanprover-community/mathlib4.git" @ "main"
+
+@[default_target]
+lean_lib Core
+
+lean_lib CatPrism_examples

--- a/core/lean/lean-toolchain
+++ b/core/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.20.0-rc5


### PR DESCRIPTION
## Summary
- configure Lake package to fetch mathlib
- specify Lean toolchain version
- update GitHub Actions to run `lake update`

## Testing
- `cargo build --release` *(failed: package manifest incomplete)*
- `lake update` *(failed: network rate limit)*
- `lake build` *(failed: network rate limit)*

------
https://chatgpt.com/codex/tasks/task_e_6852e7ac1dd0832ebfeff220f858a211