### PR TITLE
Fix binary target for parser crate

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -16,3 +16,7 @@ thiserror = "1.0"
 [features]
 default = []
 
+[[bin]]
+name = "catprism"
+path = "src/main.rs"
+


### PR DESCRIPTION
## Summary
- specify catprism binary explicitly in `parser/Cargo.toml`

## Testing
- `cargo build --release`

------
https://chatgpt.com/codex/tasks/task_e_6852f155181c832eb95f1f389641468f