### PR TITLE
Fix export-lean flag usage

### DIFF
--- a/.github/workflows/lean-ci.yml
+++ b/.github/workflows/lean-ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir -p core/lean/AutoGen
           for file in examples/*.cat; do
-            ./parser/target/release/catprism export-lean "$file" --out core/lean/AutoGen
+            ./parser/target/release/catprism export-lean --input "$file" --out core/lean/AutoGen
           done
 
       - name: 🧠 Setup Lean toolchain

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ cargo build --release
 $ ./target/release/catprism parse --json ../examples/Projection1.cat
 
 # Lean proof export
-$ ./target/release/catprism export-lean ../examples/Projection1.cat
+$ ./target/release/catprism export-lean --input ../examples/Projection1.cat
 $ cd ../core/lean && lake build
 ```
 
@@ -83,7 +83,7 @@ $ python -m http.server 9000
 * **Example 3** — Groups → Sets (Δzero, ε = 0)  
 * **Example 4** — Shape → Display with Δθ / Δlen comparison
 
-Run `catprism export-lean examples/ExampleX.cat` then `lake build` to verify.
+Run `catprism export-lean --input examples/ExampleX.cat` then `lake build` to verify.
 
 ---
 

--- a/docs/docs_Build.md
+++ b/docs/docs_Build.md
@@ -30,7 +30,7 @@ cargo build --release
 
 ### 3. `.cat` → Lean 변환
 ```bash
-./target/release/catprism export-lean examples/Projection1.cat
+./target/release/catprism export-lean --input examples/Projection1.cat
 ```
 
 ### 4. Lean 증명 빌드

--- a/docs/docs_Examples.md
+++ b/docs/docs_Examples.md
@@ -54,7 +54,7 @@
 catprism parse --json examples/Example2.cat
 
 # Lean 변환
-catprism export-lean examples/Example2.cat
+catprism export-lean --input examples/Example2.cat
 
 # Lean 증명
 cd core/lean && lake build

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,7 +46,7 @@ cargo build --release
 ## 4 · `.cat` → Lean (proof export)
 
 ```bash
-./target/release/catprism export-lean ../examples/Projection1.cat
+./target/release/catprism export-lean --input ../examples/Projection1.cat
 # → core/lean/AutoGen/Projection1.lean
 ```
 
@@ -90,7 +90,7 @@ python -m http.server 9000
 ```bash
 # 1. place MyFunctor.cat under examples/
 catprism parse --json examples/MyFunctor.cat
-catprism export-lean examples/MyFunctor.cat
+catprism export-lean --input examples/MyFunctor.cat
 cd core/lean && lake build
 ```
 
@@ -101,7 +101,7 @@ cd core/lean && lake build
 | 목적             | 명령                                           |
 | -------------- | -------------------------------------------- |
 | JSON AST       | `catprism parse --json foo.cat`              |
-| Lean export    | `catprism export-lean foo.cat`               |
+| Lean export    | `catprism export-lean --input foo.cat`       |
 | Build proofs   | `lake build` (in `core/lean`)                |
 | Local web demo | `python -m http.server 9000` (in `renderer`) |
 

--- a/release_notes_v_0_1.md
+++ b/release_notes_v_0_1.md
@@ -40,7 +40,7 @@ Run:
 
 ```bash
 catprism parse --json examples/Projection1.cat
-catprism export-lean examples/Projection1.cat
+catprism export-lean --input examples/Projection1.cat
 lake build          # inside core/lean
 ```
 


### PR DESCRIPTION
## Summary
- add `--input` flag when generating Lean files in CI
- document `--input` usage in README and docs
- fix example in release notes

## Testing
- `cargo test --manifest-path parser/Cargo.toml --no-run`


------
https://chatgpt.com/codex/tasks/task_e_6852f4793ef4832e9eaa2a8b3b845c31