### PR TITLE
Fix mathlib imports for Lean 4.20

### DIFF
--- a/core/lean/Core.lean
+++ b/core/lean/Core.lean
@@ -7,9 +7,10 @@
   • verify_comp default target
 -/
 
-import Mathlib.CategoryTheory.Category
-import Mathlib.CategoryTheory.Functor
-import Mathlib.LinearAlgebra.Basic
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Topology.MetricSpace.Basic
 open CategoryTheory
 


### PR DESCRIPTION
## Summary
- update mathlib import paths in `Core.lean`

## Testing
- `lake update` *(fails: MonoidHom.liftOfRightInverse_comp already declared)*
- `lake build` *(fails: MonoidHom.liftOfRightInverse_comp already declared)*

------
https://chatgpt.com/codex/tasks/task_e_6852fc7a24c8832eb6fae9597a76acd6