### PR TITLE
Lock mathlib commit

### DIFF
--- a/core/lean/lakefile.lean
+++ b/core/lean/lakefile.lean
@@ -3,7 +3,7 @@ open Lake DSL
 
 package CatPrism
 
-require mathlib from git "https://github.com/leanprover-community/mathlib4.git" @ "main"
+require mathlib from git "https://github.com/leanprover-community/mathlib4.git" @ "53a6dc9"
 
 @[default_target]
 lean_lib Core

--- a/core/lean/lean-toolchain
+++ b/core/lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.20.0-rc5
+leanprover/lean4:nightly-2024-05-02


### PR DESCRIPTION
## Summary
- lock mathlib dependency to commit `53a6dc9`
- update Lean toolchain to `nightly-2024-05-02`

## Testing
- `lake clean && lake update && lake build` *(fails: cannot find revision 53a6dc9)*

------
https://chatgpt.com/codex/tasks/task_e_68530395aa64832eb3e02ac843a534f6