### PR TITLE
Lock mathlib commit

### DIFF
--- a/core/lean/lakefile.lean
+++ b/core/lean/lakefile.lean
@@ -3,7 +3,7 @@ open Lake DSL
 
 package CatPrism
 
-require mathlib from git "https://github.com/leanprover-community/mathlib4.git" @ "main"
+require mathlib from git "https://github.com/leanprover-community/mathlib4.git" @ "675fd38969d2d004640fe02425a4128acc9c9f4a"
 
 @[default_target]
 lean_lib Core

--- a/core/lean/lean-toolchain
+++ b/core/lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.20.0-rc5
+leanprover/lean4:nightly-2024-05-02


### PR DESCRIPTION
## Summary
- lock mathlib dependency to commit `675fd38969d2d004640fe02425a4128acc9c9f4a`
- use Lean nightly toolchain `2024-05-02`

## Testing
- `elan --version`
- `elan toolchain install leanprover/lean4:stable`
- `elan default leanprover/lean4:stable`
- `elan show`
- `elan toolchain install leanprover/lean4:nightly-2024-05-21`
- `elan default leanprover/lean4:nightly-2024-05-21`
- `elan show`
- `lake clean && lake update && lake build` *(fails with unsolved goals in `Core.lean`)*

------
https://chatgpt.com/codex/tasks/task_e_68530395aa64832eb3e02ac843a534f6