### PR TITLE
Add identity checks to epsilon functors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CatPrism CI
+
+on:
+  push:
+    paths:
+      - 'examples/**/*.cat'
+      - 'parser/**'
+      - 'core/lean/**'
+      - 'tests/lean/**'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    paths:
+      - 'examples/**/*.cat'
+      - 'parser/**'
+      - 'core/lean/**'
+      - 'tests/lean/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build parser
+        working-directory: parser
+        run: cargo build --release
+      - name: Convert .cat files
+        run: |
+          mkdir -p core/lean/AutoGen
+          for file in examples/*.cat; do
+            ./parser/target/release/catprism export-lean --input "$file" --out core/lean/AutoGen
+          done
+      - name: Setup Lean
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+      - name: Fetch deps
+        working-directory: core/lean
+        run: lake update
+      - name: Build proofs
+        working-directory: core/lean
+        run: lake build

--- a/core/lean/CatPrism.lean
+++ b/core/lean/CatPrism.lean
@@ -1,0 +1,4 @@
+import Core
+import Core.RawPrefunctor
+import Core.EpsFunctor
+import Core.Tactics

--- a/core/lean/CatPrism_examples.lean
+++ b/core/lean/CatPrism_examples.lean
@@ -7,16 +7,17 @@
   • ShapeDisplay       – ε = 0.20 / 0.50  (PhaseDist / LengthDist)
 -/
 
-import Core
+import CatPrism
 open CategoryTheory
 
 /-! ## Example 1 : Projection1 (auto-generated) ---------------------------- -/
 
 namespace Example1Proof
   open Example1
-  def F_proj : EpsFunctor (δ := PhaseDist) 0.15 where
+  def F_proj : EpsFunctor (d := PhaseDist) 0.15 where
     F       := ProjectionFunctor  -- auto-export-lean
     comp_ok := by verify_comp
+    id_ok   := by verify_id
 end Example1Proof
 
 
@@ -28,9 +29,10 @@ variable {n : ℕ} (n)
 -- (MatObj, PhaseObj, PhaseFunctor 정의는 이전과 동일)
 
 noncomputable def F_mat_phase (n) :
-    EpsFunctor (δ := PhaseDist) 0.30 where
+    EpsFunctor (d := PhaseDist) 0.30 where
   F       := PhaseFunctor n
   comp_ok := by verify_comp             -- δθ triangle ≤ ε
+  id_ok   := by verify_id
 
 end MatrixPhase
 
@@ -40,9 +42,10 @@ end MatrixPhase
 namespace GroupForget
 open GroupCat
 
-def ForgetGroups : EpsFunctor (δ := Δzero) 0 where
+def ForgetGroups : EpsFunctor (d := Δzero) 0 where
   F       := CategoryTheory.forget _
   comp_ok := by verify_comp
+  id_ok   := by verify_id
 end GroupForget
 
 
@@ -51,12 +54,14 @@ end GroupForget
 namespace ShapeDisplay
 -- (Shape/Display 범주, HasPhase·HasLength 인스턴스 가정)
 
-def F_shape_phase : EpsFunctor (δ := PhaseDist) 0.2 where
+def F_shape_phase : EpsFunctor (d := PhaseDist) 0.2 where
   F       := ShapeToDisplayPhase   -- 가정된 functor
   comp_ok := by verify_comp
+  id_ok   := by verify_id
 
-def F_shape_len : EpsFunctor (δ := LengthDist) 0.5 where
+def F_shape_len : EpsFunctor (d := LengthDist) 0.5 where
   F       := ShapeToDisplayLen     -- 가정된 functor
   comp_ok := by verify_comp
+  id_ok   := by verify_id
 end ShapeDisplay
 

--- a/core/lean/Core.lean
+++ b/core/lean/Core.lean
@@ -8,6 +8,7 @@ import Core.EpsFunctor
 import Core.Tactics
 
 open CategoryTheory
+open Core.EpsFunctor
 
 universe u
 

--- a/core/lean/Core.lean
+++ b/core/lean/Core.lean
@@ -3,6 +3,9 @@ import Mathlib.CategoryTheory.Functor.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Topology.MetricSpace.Basic
+import Core.RawPrefunctor
+import Core.EpsFunctor
+import Core.Tactics
 
 open CategoryTheory
 
@@ -28,15 +31,6 @@ def LengthDist {C} [CatPrismCategory C] [HasLength (C := C)]
 
 def Δzero {C} [CatPrismCategory C] {A B : C} (_f g : A ⟶ B) : ℝ := 0
 
-/-- ε-functor preserving composition within ε under pseudometric `d`. -/
-structure EpsFunctor
-    {C D : Type u} [CatPrismCategory C] [CatPrismCategory D]
-    (d : {A B : C} → (A ⟶ B) → (A ⟶ B) → ℝ) (ε : ℝ) where
-  F : C ⥤ D
-  comp_ok :
-    ∀ {A B C₁ : C} (f : A ⟶ B) (g : B ⟶ C₁),
-      d (F.map (g ≫ f)) ((F.map f) ≫ (F.map g)) ≤ ε
-
 /-! ### Example category: `UnitCat` -/
 
 inductive UnitCat
@@ -51,9 +45,3 @@ instance : HasPhase (C := UnitCat) where
   phase     := fun {_ _} _ ↦ 0
   phase_arg := by
     intro; simp [Real.pi_pos.le]
-
-def IdFunctor : EpsFunctor (d := PhaseDist) 0 where
-  F := { obj := id, map := fun _ ↦ PUnit.unit }
-  comp_ok := by
-    intro _ _ _ _ _    -- 모든 인자 무시 → 경고 없음
-    simp [PhaseDist]   -- 0 ≤ 0 → `simp`

--- a/core/lean/Core.lean
+++ b/core/lean/Core.lean
@@ -1,47 +1,58 @@
 import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Tactic
 import Mathlib.Data.Real.Basic
-import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
-import Mathlib.Topology.MetricSpace.Basic
-import Core.RawPrefunctor
-import Core.EpsFunctor
-import Core.Tactics
 
 open CategoryTheory
 
 universe u
 
-class CatPrismCategory (C : Type u) extends Category C
+/--
+`EpsFunctor d ε` is an *ε‑functor* between categories `C` and `D`.  Instead of preserving
+composition and identities strictly, it does so *up to a numerical error* `ε`, measured by the
+user‑supplied *distortion metric* `d` on morphisms of `D`.
 
-class HasPhase {C} [CatPrismCategory C] where
-  phase     : {A B : C} → (A ⟶ B) → ℝ
-  phase_arg : ∀ {A B : C} (f : A ⟶ B), |phase f| ≤ Real.pi
+* `d f g` should be thought of as the "distance" between two parallel morphisms `f` and `g` in
+  `D`.  No axioms on `d` are required—any real‑valued function will do—but typical examples are
+  metrics coming from a norm or an absolute value.
+* When `ε = 0` and `d` is the discrete metric, an `EpsFunctor` is just an ordinary functor.
+* If `ε = 0` but `d` is non‑trivial, we obtain *isometric* functors, useful in analysis.
+-/
+structure EpsFunctor
+    {C D : Type u} [Category C] [Category D]
+    (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
+    (ε : ℝ) : Type (max u (u+1)) where
+  /-- Object mapping. -/
+  objMap : C → D
+  /-- Morphism mapping. -/
+  map    : {A B : C} → (A ⟶ B) → (objMap A ⟶ objMap B)
+  /-- Composition is preserved *up to* `ε`. -/
+  comp_ok : ∀ {A B C₁ : C} (f : A ⟶ B) (g : B ⟶ C₁),
+      d (map (g ≫ f)) ((map f) ≫ (map g)) ≤ ε
+  /-- Identities are preserved *up to* `ε`. -/
+  id_ok   : ∀ {A : C}, d (map (𝟙 A)) (𝟙 (objMap A)) ≤ ε
 
-def PhaseDist {C} [CatPrismCategory C] [HasPhase (C := C)]
-    {A B : C} (f g : A ⟶ B) : ℝ :=
-  |HasPhase.phase f - HasPhase.phase g|
+attribute [simp] EpsFunctor.objMap
+attribute [simp] EpsFunctor.map
 
-class HasLength {C} [CatPrismCategory C] where
-  length     : {A B : C} → (A ⟶ B) → ℝ
-  len_nonneg : ∀ {A B : C} (f : A ⟶ B), 0 ≤ length f
+namespace EpsFunctor
 
-def LengthDist {C} [CatPrismCategory C] [HasLength (C := C)]
-    {A B : C} (f g : A ⟶ B) : ℝ :=
-  |HasLength.length f - HasLength.length g|
+variable {C D : Type u} [Category C] [Category D]
+variable {d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ} {ε : ℝ}
 
-def Δzero {C} [CatPrismCategory C] {A B : C} (_f g : A ⟶ B) : ℝ := 0
+/-- A strict functor is automatically a `0`‑ε functor. -/
+@[simp]
+def fromStrict
+    (F : C ⥤ D) (d)
+    [∀ {A B : D} (f : A ⟶ B), Decidable (d f f = 0)] :
+    EpsFunctor d 0 where
+  objMap := F.obj
+  map    := @fun A B f => F.map f
+  comp_ok := by
+    intro A B C₁ f g
+    simp [F.map_comp]
+  id_ok := by
+    intro A
+    simp [F.map_id]
 
-/-! ### Example category: `UnitCat` -/
-
-inductive UnitCat
-| star
-
-instance : CatPrismCategory UnitCat where
-  Hom  := fun _ _ ↦ PUnit
-  id   := fun _ ↦ PUnit.unit
-  comp := @fun _ _ _ _ _ ↦ PUnit.unit
-
-instance : HasPhase (C := UnitCat) where
-  phase     := fun {_ _} _ ↦ 0
-  phase_arg := by
-    intro; simp [Real.pi_pos.le]
+end EpsFunctor

--- a/core/lean/Core/EpsFunctor.lean
+++ b/core/lean/Core/EpsFunctor.lean
@@ -1,62 +1,47 @@
 import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.CategoryTheory.Functor.Basic
 import Mathlib.Data.Real.Basic
+import Core.RawPrefunctor
+import Core.Tactics
 
 open CategoryTheory
 
-/-!
-  # `EpsFunctor` — ε‑approximate functors
-
-  *   **Goal** : capture functors that preserve identities and composition *up to a real error ε*,
-      measured by a user‑supplied distortion pseudo‑metric `d` on morphisms of the *target* category.
-  *   **Notation** : `d f g` is the distance between two morphisms `f`,`g : A ⟶ B` in `D`.
-  *   **Laws**   :
-
-        `d (F.map (g ≫ f)) ((F.map f) ≫ (F.map g)) ≤ ε`
-        `d (F.map (𝟙 A)) (𝟙 (F.obj A))               ≤ ε`
-
-      When `ε = 0` and `d` is a genuine metric, we recover ordinary functors.
--!/
-
 universe u
 
-/--
-An **ε‑functor** between categories `C` and `D`.  The parameter `d` measures how far two
-morphisms of `D` are, while `ε` bounds the functorial error.  When `ε = 0`, every `EpsFunctor d 0`
-is strictly functorial.
--/
+variable {C D : Type u}
+variable [CatPrismCategory C] [CatPrismCategory D]
+
+instance instQuiverC : Quiver C := inferInstance
+instance instCategoryC : Category C := inferInstance
+instance instQuiverD : Quiver D := inferInstance
+instance instCategoryD : Category D := inferInstance
+
+/-- ε-functor now checks identities. -/
 structure EpsFunctor
-    {C D : Type u} [Category C] [Category D]
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
     (ε : ℝ) : Type u where
-  /-- Object part of the ε‑functor. -/
-  objMap : C → D
-  /-- Morphism part. -/
-  map    : {A B : C} → (A ⟶ B) → (objMap A ⟶ objMap B)
-  /-- Composition is preserved up to ε. -/
+  @[simp] obj_map : C → D
+  @[simp] map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
   comp_ok :
-    ∀ {A B C'} (f : A ⟶ B) (g : B ⟶ C'),
+    ∀ {A B C₁} (f : A ⟶ B) (g : B ⟶ C₁),
       d (map (g ≫ f)) ((map f) ≫ (map g)) ≤ ε
-  /-- Identities are preserved up to ε. -/
-  id_ok :
-    ∀ {A}, d (map (𝟙 A)) (𝟙 (objMap A)) ≤ ε
+  id_ok   :
+    ∀ {A}, d (map (𝟙 A)) (𝟙 (obj_map A)) ≤ ε
 
-namespace EpsFunctor
-
-/-- Promote an ordinary functor to a *perfect* (`ε = 0`) ε‑functor. -/
-def fromStrict
-    {C D : Type u} [Category C] [Category D]
+/-- Embed a strict functor as 0-ε ε-functor. -/
+@[simp]
+def EpsFunctor.fromStrict
     (F : C ⥤ D)
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
     [∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
-    EpsFunctor d 0 :=
-  { objMap := F.obj,
-    map    := F.map,
-    comp_ok := by
-      intro A B C' f g
-      simp [F.map_comp],
-    id_ok := by
-      intro A
-      simp [F.map_id] }
-
-end EpsFunctor
+    EpsFunctor (C := C) (D := D) d 0 := by
+  classical
+  refine {
+    obj_map := F.obj,
+    map := F.map,
+    comp_ok := ?_,
+    id_ok := ?_ }
+  · intro A B C₁ f g
+    simp [F.map_comp]
+  · intro A
+    simp [F.map_id]

--- a/core/lean/Core/EpsFunctor.lean
+++ b/core/lean/Core/EpsFunctor.lean
@@ -1,47 +1,62 @@
 import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.CategoryTheory.Functor.Basic
 import Mathlib.Data.Real.Basic
-import Core.RawPrefunctor
-import Core.Tactics
 
 open CategoryTheory
 
+/-!
+  # `EpsFunctor` — ε‑approximate functors
+
+  *   **Goal** : capture functors that preserve identities and composition *up to a real error ε*,
+      measured by a user‑supplied distortion pseudo‑metric `d` on morphisms of the *target* category.
+  *   **Notation** : `d f g` is the distance between two morphisms `f`,`g : A ⟶ B` in `D`.
+  *   **Laws**   :
+
+        `d (F.map (g ≫ f)) ((F.map f) ≫ (F.map g)) ≤ ε`
+        `d (F.map (𝟙 A)) (𝟙 (F.obj A))               ≤ ε`
+
+      When `ε = 0` and `d` is a genuine metric, we recover ordinary functors.
+-!/
+
 universe u
 
-variable {C D : Type u}
-variable [CatPrismCategory C] [CatPrismCategory D]
-
-instance instQuiverC : Quiver C := inferInstance
-instance instCategoryC : Category C := inferInstance
-instance instQuiverD : Quiver D := inferInstance
-instance instCategoryD : Category D := inferInstance
-
-/-- ε-functor now checks identities. -/
+/--
+An **ε‑functor** between categories `C` and `D`.  The parameter `d` measures how far two
+morphisms of `D` are, while `ε` bounds the functorial error.  When `ε = 0`, every `EpsFunctor d 0`
+is strictly functorial.
+-/
 structure EpsFunctor
+    {C D : Type u} [Category C] [Category D]
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
     (ε : ℝ) : Type u where
-  @[simp] obj_map : C → D
-  @[simp] map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
+  /-- Object part of the ε‑functor. -/
+  objMap : C → D
+  /-- Morphism part. -/
+  map    : {A B : C} → (A ⟶ B) → (objMap A ⟶ objMap B)
+  /-- Composition is preserved up to ε. -/
   comp_ok :
-    ∀ {A B C₁} (f : A ⟶ B) (g : B ⟶ C₁),
+    ∀ {A B C'} (f : A ⟶ B) (g : B ⟶ C'),
       d (map (g ≫ f)) ((map f) ≫ (map g)) ≤ ε
-  id_ok   :
-    ∀ {A}, d (map (𝟙 A)) (𝟙 (obj_map A)) ≤ ε
+  /-- Identities are preserved up to ε. -/
+  id_ok :
+    ∀ {A}, d (map (𝟙 A)) (𝟙 (objMap A)) ≤ ε
 
-/-- Embed a strict functor as 0-ε ε-functor. -/
-@[simp]
-def EpsFunctor.fromStrict
+namespace EpsFunctor
+
+/-- Promote an ordinary functor to a *perfect* (`ε = 0`) ε‑functor. -/
+def fromStrict
+    {C D : Type u} [Category C] [Category D]
     (F : C ⥤ D)
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
     [∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
-    EpsFunctor (C := C) (D := D) d 0 := by
-  classical
-  refine {
-    obj_map := F.obj,
-    map := F.map,
-    comp_ok := ?_,
-    id_ok := ?_ }
-  · intro A B C₁ f g
-    simp [F.map_comp]
-  · intro A
-    simp [F.map_id]
+    EpsFunctor d 0 :=
+  { objMap := F.obj,
+    map    := F.map,
+    comp_ok := by
+      intro A B C' f g
+      simp [F.map_comp],
+    id_ok := by
+      intro A
+      simp [F.map_id] }
+
+end EpsFunctor

--- a/core/lean/Core/EpsFunctor.lean
+++ b/core/lean/Core/EpsFunctor.lean
@@ -1,0 +1,40 @@
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Real.Basic
+import Core.RawPrefunctor
+
+open CategoryTheory
+
+universe u
+
+/-- ε-functor now checks identities. -/
+structure EpsFunctor {C D : Type u} [CatPrismCategory C] [CatPrismCategory D]
+    (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ) (ε : ℝ) where
+  obj_map : C → D
+  map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
+  comp_ok :
+    ∀ {A B C₁} (f : A ⟶ B) (g : B ⟶ C₁),
+      d (map (g ≫ f)) ((map f) ≫ (map g)) ≤ ε
+  id_ok   :
+    ∀ {A}, d (map (𝟙 A)) (𝟙 (obj_map A)) ≤ ε
+
+/-- Embed a strict functor as 0-ε ε-functor. -/
+@[simp]
+def EpsFunctor.fromStrict {C D : Type u} [CatPrismCategory C] [CatPrismCategory D]
+    (F : C ⥤ D)
+    (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
+    [h : ∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
+    EpsFunctor d 0 := by
+  classical
+  refine {
+    obj_map := F.obj,
+    map := ?_,
+    comp_ok := ?_,
+    id_ok := ?_ }
+  · intro A B f; exact F.map f
+  · intro A B C₁ f g
+    have := F.map_comp f g
+    simp [this, h]
+  · intro A
+    have := F.map_id A
+    simp [this, h]

--- a/core/lean/Core/EpsFunctor.lean
+++ b/core/lean/Core/EpsFunctor.lean
@@ -11,12 +11,17 @@ universe u
 variable {C D : Type u}
 variable [CatPrismCategory C] [CatPrismCategory D]
 
+instance instQuiverC : Quiver C := inferInstance
+instance instCategoryC : Category C := inferInstance
+instance instQuiverD : Quiver D := inferInstance
+instance instCategoryD : Category D := inferInstance
+
 /-- ε-functor now checks identities. -/
 structure EpsFunctor
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
     (ε : ℝ) : Type u where
-  obj_map : C → D
-  map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
+  @[simp] obj_map : C → D
+  @[simp] map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
   comp_ok :
     ∀ {A B C₁} (f : A ⟶ B) (g : B ⟶ C₁),
       d (map (g ≫ f)) ((map f) ≫ (map g)) ≤ ε
@@ -28,18 +33,15 @@ structure EpsFunctor
 def EpsFunctor.fromStrict
     (F : C ⥤ D)
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
-    [h : ∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
+    [∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
     EpsFunctor (C := C) (D := D) d 0 := by
   classical
   refine {
     obj_map := F.obj,
-    map := ?_,
+    map := F.map,
     comp_ok := ?_,
     id_ok := ?_ }
-  · intro A B f; exact F.map f
   · intro A B C₁ f g
-    have := F.map_comp f g
-    simp [this, h]
+    simp [F.map_comp]
   · intro A
-    have := F.map_id A
-    simp [this, h]
+    simp [F.map_id]

--- a/core/lean/Core/EpsFunctor.lean
+++ b/core/lean/Core/EpsFunctor.lean
@@ -1,47 +1,56 @@
 import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.CategoryTheory.Functor.Basic
 import Mathlib.Data.Real.Basic
-import Core.RawPrefunctor
-import Core.Tactics
 
 open CategoryTheory
 
 universe u
 
-variable {C D : Type u}
-variable [CatPrismCategory C] [CatPrismCategory D]
+/--
+`EpsFunctor d ε` is an *ε‑approximate functor* between categories `C` and `D`.  Instead of
+requiring exact functoriality, it allows the image of identities and compositions to deviate by at
+most `ε` with respect to a user‑supplied *distortion metric* `d` on morphisms of `D`.
+- `d f g` measures the distance between two morphisms `f` and `g` in `D`.
+- `ε : ℝ` is the tolerated bound (`ε ≥ 0` is assumed by the user).
 
-instance instQuiverC : Quiver C := inferInstance
-instance instCategoryC : Category C := inferInstance
-instance instQuiverD : Quiver D := inferInstance
-instance instCategoryD : Category D := inferInstance
-
-/-- ε-functor now checks identities. -/
+Only the ordinary categorical structures from `Mathlib` are required, so this file does **not**
+import the domain‑specific `CatPrism*` modules.  Project files can provide the relevant instances
+when instantiating an `EpsFunctor`.
+-/
 structure EpsFunctor
-    (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
-    (ε : ℝ) : Type u where
-  @[simp] obj_map : C → D
-  @[simp] map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
+    {C D : Type u} [Category C] [Category D]
+    (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ) (ε : ℝ) : Type (max u 1) where
+  /-- Object mapping. -/
+  objMap : C → D
+  /-- Morphism mapping. -/
+  map    : {A B : C} → (A ⟶ B) → (objMap A ⟶ objMap B)
+  /-- Composition is preserved up to `ε`. -/
   comp_ok :
-    ∀ {A B C₁} (f : A ⟶ B) (g : B ⟶ C₁),
-      d (map (g ≫ f)) ((map f) ≫ (map g)) ≤ ε
-  id_ok   :
-    ∀ {A}, d (map (𝟙 A)) (𝟙 (obj_map A)) ≤ ε
+    ∀ {A B C'} (f : A ⟶ B) (g : B ⟶ C'),
+      d (map (f ≫ g)) (map f ≫ map g) ≤ ε
+  /-- Identities are preserved up to `ε`. -/
+  id_ok   : ∀ {A}, d (map (𝟙 A)) (𝟙 (objMap A)) ≤ ε
 
-/-- Embed a strict functor as 0-ε ε-functor. -/
+attribute [simp] EpsFunctor.objMap EpsFunctor.map
+
+/-- Embed a strict functor as a `0`‑ε functor. -/
 @[simp]
 def EpsFunctor.fromStrict
+    {C D : Type u} [Category C] [Category D]
     (F : C ⥤ D)
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
     [∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
     EpsFunctor (C := C) (D := D) d 0 := by
   classical
-  refine {
-    obj_map := F.obj,
-    map := F.map,
-    comp_ok := ?_,
-    id_ok := ?_ }
-  · intro A B C₁ f g
-    simp [F.map_comp]
-  · intro A
-    simp [F.map_id]
+  exact
+    { objMap := F.obj,
+      map    := F.map,
+      comp_ok := by
+        intro A B C' f g
+        -- `map` is strict, so the distance is zero.
+        change d _ _ ≤ 0
+        simp [F.map_comp, le_of_eq] at *,
+      id_ok := by
+        intro A
+        change d _ _ ≤ 0
+        simp [F.map_id, le_of_eq] }

--- a/core/lean/Core/EpsFunctor.lean
+++ b/core/lean/Core/EpsFunctor.lean
@@ -2,14 +2,19 @@ import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.CategoryTheory.Functor.Basic
 import Mathlib.Data.Real.Basic
 import Core.RawPrefunctor
+import Core.Tactics
 
 open CategoryTheory
 
 universe u
 
+variable {C D : Type u}
+variable [CatPrismCategory C] [CatPrismCategory D]
+
 /-- ε-functor now checks identities. -/
-structure EpsFunctor {C D : Type u} [CatPrismCategory C] [CatPrismCategory D]
-    (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ) (ε : ℝ) where
+structure EpsFunctor
+    (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
+    (ε : ℝ) : Type u where
   obj_map : C → D
   map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
   comp_ok :
@@ -20,11 +25,11 @@ structure EpsFunctor {C D : Type u} [CatPrismCategory C] [CatPrismCategory D]
 
 /-- Embed a strict functor as 0-ε ε-functor. -/
 @[simp]
-def EpsFunctor.fromStrict {C D : Type u} [CatPrismCategory C] [CatPrismCategory D]
+def EpsFunctor.fromStrict
     (F : C ⥤ D)
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
     [h : ∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
-    EpsFunctor d 0 := by
+    EpsFunctor (C := C) (D := D) d 0 := by
   classical
   refine {
     obj_map := F.obj,

--- a/core/lean/Core/RawPrefunctor.lean
+++ b/core/lean/Core/RawPrefunctor.lean
@@ -1,0 +1,10 @@
+import Mathlib.CategoryTheory.Category.Basic
+
+open CategoryTheory
+
+universe u
+
+/-- Raw object & morphism mapping, no laws. -/
+structure RawPrefunctor {C D : Type u} [Category C] [Category D] where
+  objMap : C → D
+  morMap : {A B : C} → (A ⟶ B) → (objMap A ⟶ objMap B)

--- a/core/lean/Core/Tactics.lean
+++ b/core/lean/Core/Tactics.lean
@@ -1,0 +1,5 @@
+import Mathlib.Tactic
+
+macro "verify_id" : tactic => `(tactic| simp)
+
+macro "verify_comp" : tactic => `(tactic| simp)

--- a/core/lean/Core/Tactics.lean
+++ b/core/lean/Core/Tactics.lean
@@ -1,5 +1,17 @@
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Real.Basic
+import Core.RawPrefunctor
 import Mathlib.Tactic
+open CategoryTheory
+open Lean Elab Tactic
 
-macro "verify_id" : tactic => `(tactic| simp)
+elab "verify_id" : tactic => do
+  evalTactic (← `(tactic|
+    first
+      | simp
+      | apply le_of_eq; simp
+      | linarith))
 
 macro "verify_comp" : tactic => `(tactic| simp)
+

--- a/docs/approx_functor.md
+++ b/docs/approx_functor.md
@@ -1,0 +1,15 @@
+# ε-Approximate Functor
+
+This document describes CatPrism's notion of an approximate functor.
+
+## ε-Identity compatibility
+
+From this version each `EpsFunctor` also checks how identity maps
+are preserved.  The generator inserts a proof stub
+
+```lean
+id_ok := by verify_id
+```
+
+so downstream proofs can rely on the functor being close to identity
+on objects and morphisms.

--- a/docs/docs_EpsFunctor.md
+++ b/docs/docs_EpsFunctor.md
@@ -16,6 +16,28 @@ structure EpsFunctor
                   δ (F.map (g ≫ f)) (F.map g ≫ F.map f) ≤ ε
 ```
 
+일반 `Category` 맥락에서 사용하려면 `Quiver` 인스턴스를
+명시적으로 선언할 수 있다:
+
+```lean
+import Mathlib.CategoryTheory.Category.Basic
+
+universe u v
+
+variable {C D : Type u}
+variable [QC : Quiver C] [QD : Quiver D]
+variable [Category C] [Category D]
+
+structure EpsFunctor
+    (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
+    (ε : ℝ) : Type (max u v) where
+  obj_map : C → D
+  map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
+  comp_ok : ∀ {A B C₁ : C} (f : A ⟶ B) (g : B ⟶ C₁),
+              d (map (g ≫ f)) ((map f) ≫ (map g)) ≤ ε
+  id_ok   : ∀ {A : C}, d (map (𝟙 A)) (𝟙 (obj_map A)) ≤ ε
+```
+
 - `δ`: 두 사상 간 거리 (PhaseDist, LengthDist 등)
 - `ε`: 합성 왜곡 허용 범위
 - `F`: 표준 범주론 펑터

--- a/examples/RotApprox.cat
+++ b/examples/RotApprox.cat
@@ -1,0 +1,10 @@
+category S { object A, morphism r : A -> A }
+category T { object B, morphism s : B -> B }
+metric Δzero { lambda (f,g) => 0 }
+functor RotF from S to T {
+  object_map { A -> B }
+  morphism_map { r -> s }
+  epsilon           : 0
+  distortion_metric : Δzero
+  rule              : preserve_composition_within ε
+}

--- a/parser/templates/functor.lean
+++ b/parser/templates/functor.lean
@@ -4,12 +4,12 @@
   ε-Functor proof with δ = {metric}, ε = {epsilon}
 -/
 
-import Core
+import CatPrism
 open CategoryTheory
 
 namespace {namespace}
 
-def {functor_name} : EpsFunctor (δ := {metric}) {epsilon} where
+def {functor_name} : EpsFunctor (d := {metric}) {epsilon} where
   F := {
     obj := fun X => match X with
 {object_map}
@@ -20,5 +20,6 @@ def {functor_name} : EpsFunctor (δ := {metric}) {epsilon} where
 
   comp_ok := by
 {proof_block}
+  id_ok   := by verify_id
 
 end {namespace}

--- a/tests/lean/FunctorIdentity.lean
+++ b/tests/lean/FunctorIdentity.lean
@@ -1,3 +1,9 @@
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Real.Basic
+import Core.RawPrefunctor
+import Core.Tactics
+open CategoryTheory
 import CatPrism
 
 def IdTest : EpsFunctor (d := fun _ _ _ => (0 : ℝ)) 0 := by

--- a/tests/lean/FunctorIdentity.lean
+++ b/tests/lean/FunctorIdentity.lean
@@ -4,6 +4,7 @@ import Mathlib.Data.Real.Basic
 import Core.RawPrefunctor
 import Core.Tactics
 open CategoryTheory
+open Core.EpsFunctor
 import CatPrism
 
 def IdTest : EpsFunctor (d := fun _ _ _ => (0 : ℝ)) 0 := by

--- a/tests/lean/FunctorIdentity.lean
+++ b/tests/lean/FunctorIdentity.lean
@@ -1,0 +1,8 @@
+import CatPrism
+
+def IdTest : EpsFunctor (d := fun _ _ _ => (0 : ℝ)) 0 := by
+  refine ⟨(fun x => x), (fun f => f), ?_, ?_⟩
+  · intro A B C f g; simp
+  · intro A; simp
+
+#eval 1

--- a/tests/lean/PhaseMetric.lean
+++ b/tests/lean/PhaseMetric.lean
@@ -1,0 +1,18 @@
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Real.Basic
+import Core.RawPrefunctor
+import Core.Tactics
+open CategoryTheory
+import CatPrism
+
+/-- EpsFunctor on `UnitCat` using `PhaseDist` as the metric. -/
+def UnitPhaseId : EpsFunctor (d := PhaseDist) 0 := by
+  refine {
+    obj_map := fun _ => UnitCat.star,
+    map := fun {A B} f => PUnit.unit,
+    comp_ok := ?_,
+    id_ok := ?_ }
+  · intro A B C f g; verify_comp
+  · intro A; verify_id
+

--- a/tests/lean/PhaseMetric.lean
+++ b/tests/lean/PhaseMetric.lean
@@ -4,12 +4,13 @@ import Mathlib.Data.Real.Basic
 import Core.RawPrefunctor
 import Core.Tactics
 open CategoryTheory
+open Core.EpsFunctor
 import CatPrism
 
 /-- EpsFunctor on `UnitCat` using `PhaseDist` as the metric. -/
 def UnitPhaseId : EpsFunctor (d := PhaseDist) 0 := by
   refine {
-    obj_map := fun _ => UnitCat.star,
+    objMap := fun _ => UnitCat.star,
     map := fun {A B} f => PUnit.unit,
     comp_ok := ?_,
     id_ok := ?_ }

--- a/tests/lean/UnitEps.lean
+++ b/tests/lean/UnitEps.lean
@@ -1,0 +1,18 @@
+open Core.EpsFunctor
+open CategoryTheory
+
+variable {d : {A B : UnitCat} → (A ⟶ B) → (A ⟶ B) → ℝ}
+variable (ε : ℝ)
+
+/-- trivial ε-functor on the UnitCat – compiles / test -/
+def UnitEps (hε : 0 ≤ ε) : Core.EpsFunctor.EpsFunctor d ε where
+  objMap := fun _ ↦ UnitCat.star
+  map := by
+    intro _ _ _
+    exact PUnit.unit
+  comp_ok := by
+    intro _ _ _ _ _
+    simpa using le_of_eq (by simp)
+  id_ok := by
+    intro _
+    simpa using le_of_eq (by simp)


### PR DESCRIPTION
## Summary
- extend Lean core with new `EpsFunctor` that includes `id_ok`
- provide simple verification tactics and raw functor structure
- update generator template to emit `id_ok := by verify_id`
- add example and docs for ε‑identity compatibility
- include a golden test and CI workflow

## Testing
- `lake build` *(fails: invalid binder annotation)*

------
https://chatgpt.com/codex/tasks/task_e_6853bae33c34832ea6d6af6bf4a928b5