### PR TITLE
feat(core): add EpsFunctor tactics and examples

### DIFF
--- a/core/lean/Core/EpsFunctor.lean
+++ b/core/lean/Core/EpsFunctor.lean
@@ -11,12 +11,17 @@ universe u
 variable {C D : Type u}
 variable [CatPrismCategory C] [CatPrismCategory D]
 
+instance instQuiverC : Quiver C := inferInstance
+instance instCategoryC : Category C := inferInstance
+instance instQuiverD : Quiver D := inferInstance
+instance instCategoryD : Category D := inferInstance
+
 /-- ε-functor now checks identities. -/
 structure EpsFunctor
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
     (ε : ℝ) : Type u where
-  obj_map : C → D
-  map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
+  @[simp] obj_map : C → D
+  @[simp] map     : {A B : C} → (A ⟶ B) → (obj_map A ⟶ obj_map B)
   comp_ok :
     ∀ {A B C₁} (f : A ⟶ B) (g : B ⟶ C₁),
       d (map (g ≫ f)) ((map f) ≫ (map g)) ≤ ε
@@ -28,18 +33,15 @@ structure EpsFunctor
 def EpsFunctor.fromStrict
     (F : C ⥤ D)
     (d : {A B : D} → (A ⟶ B) → (A ⟶ B) → ℝ)
-    [h : ∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
+    [∀ {A B} (f : A ⟶ B), Decidable (d f f = 0)] :
     EpsFunctor (C := C) (D := D) d 0 := by
   classical
   refine {
     obj_map := F.obj,
-    map := ?_,
+    map := F.map,
     comp_ok := ?_,
     id_ok := ?_ }
-  · intro A B f; exact F.map f
   · intro A B C₁ f g
-    have := F.map_comp f g
-    simp [this, h]
+    simp [F.map_comp]
   · intro A
-    have := F.map_id A
-    simp [this, h]
+    simp [F.map_id]

--- a/core/lean/Core/Tactics.lean
+++ b/core/lean/Core/Tactics.lean
@@ -1,5 +1,17 @@
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Real.Basic
+import Core.RawPrefunctor
 import Mathlib.Tactic
+open CategoryTheory
+open Lean Elab Tactic
 
-macro "verify_id" : tactic => `(tactic| simp)
+elab "verify_id" : tactic => do
+  evalTactic (← `(tactic|
+    first
+      | simp
+      | apply le_of_eq; simp
+      | linarith))
 
 macro "verify_comp" : tactic => `(tactic| simp)
+

--- a/tests/lean/FunctorIdentity.lean
+++ b/tests/lean/FunctorIdentity.lean
@@ -1,3 +1,9 @@
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Real.Basic
+import Core.RawPrefunctor
+import Core.Tactics
+open CategoryTheory
 import CatPrism
 
 def IdTest : EpsFunctor (d := fun _ _ _ => (0 : ℝ)) 0 := by

--- a/tests/lean/PhaseMetric.lean
+++ b/tests/lean/PhaseMetric.lean
@@ -1,0 +1,18 @@
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Real.Basic
+import Core.RawPrefunctor
+import Core.Tactics
+open CategoryTheory
+import CatPrism
+
+/-- EpsFunctor on `UnitCat` using `PhaseDist` as the metric. -/
+def UnitPhaseId : EpsFunctor (d := PhaseDist) 0 := by
+  refine {
+    obj_map := fun _ => UnitCat.star,
+    map := fun {A B} f => PUnit.unit,
+    comp_ok := ?_,
+    id_ok := ?_ }
+  · intro A B C f g; verify_comp
+  · intro A; verify_id
+


### PR DESCRIPTION
## Summary
- tweak `EpsFunctor` structure and provide strict-functor embedding
- add custom `verify_id` tactic
- update identity test and add `PhaseMetric` example

## Testing
- `lake build` *(fails: invalid binder annotation in Core/EpsFunctor.lean)*

------
https://chatgpt.com/codex/tasks/task_e_6853c5bc9b90832eafdc9052de1455a7