### PR TITLE
Fix EpsFunctor field names

### DIFF
--- a/core/lean/Core.lean
+++ b/core/lean/Core.lean
@@ -8,6 +8,7 @@ import Core.EpsFunctor
 import Core.Tactics
 
 open CategoryTheory
+open Core.EpsFunctor
 
 universe u
 

--- a/tests/lean/FunctorIdentity.lean
+++ b/tests/lean/FunctorIdentity.lean
@@ -4,6 +4,7 @@ import Mathlib.Data.Real.Basic
 import Core.RawPrefunctor
 import Core.Tactics
 open CategoryTheory
+open Core.EpsFunctor
 import CatPrism
 
 def IdTest : EpsFunctor (d := fun _ _ _ => (0 : ℝ)) 0 := by

--- a/tests/lean/PhaseMetric.lean
+++ b/tests/lean/PhaseMetric.lean
@@ -4,12 +4,13 @@ import Mathlib.Data.Real.Basic
 import Core.RawPrefunctor
 import Core.Tactics
 open CategoryTheory
+open Core.EpsFunctor
 import CatPrism
 
 /-- EpsFunctor on `UnitCat` using `PhaseDist` as the metric. -/
 def UnitPhaseId : EpsFunctor (d := PhaseDist) 0 := by
   refine {
-    obj_map := fun _ => UnitCat.star,
+    objMap := fun _ => UnitCat.star,
     map := fun {A B} f => PUnit.unit,
     comp_ok := ?_,
     id_ok := ?_ }

--- a/tests/lean/UnitEps.lean
+++ b/tests/lean/UnitEps.lean
@@ -1,0 +1,18 @@
+open Core.EpsFunctor
+open CategoryTheory
+
+variable {d : {A B : UnitCat} → (A ⟶ B) → (A ⟶ B) → ℝ}
+variable (ε : ℝ)
+
+/-- trivial ε-functor on the UnitCat – compiles / test -/
+def UnitEps (hε : 0 ≤ ε) : Core.EpsFunctor.EpsFunctor d ε where
+  objMap := fun _ ↦ UnitCat.star
+  map := by
+    intro _ _ _
+    exact PUnit.unit
+  comp_ok := by
+    intro _ _ _ _ _
+    simpa using le_of_eq (by simp)
+  id_ok := by
+    intro _
+    simpa using le_of_eq (by simp)


### PR DESCRIPTION
## Summary
- open `Core.EpsFunctor` in `Core.lean`
- update tests to use `objMap` field
- add example `UnitEps`

## Testing
- `lake build` *(fails: network restrictions prevent completion)*

------
https://chatgpt.com/codex/tasks/task_e_6853d990a7e8832e833246dd07814d56