### PR TITLE
Fix parse docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ cargo build --release
 
 ```bash
 # JSON AST for renderer
-$ ./target/release/catprism parse --json ../examples/Projection1.cat
+$ ./target/release/catprism parse --input ../examples/Projection1.cat --output ../examples/Projection1.cat.ast.json
 
 # Lean proof export
 $ ./target/release/catprism export-lean --input ../examples/Projection1.cat

--- a/docs/docs_Build.md
+++ b/docs/docs_Build.md
@@ -25,7 +25,7 @@ cargo build --release
 
 ### 2. `.cat` → JSON AST
 ```bash
-./target/release/catprism parse --json examples/Projection1.cat
+./target/release/catprism parse --input examples/Projection1.cat --output examples/Projection1.cat.ast.json
 ```
 
 ### 3. `.cat` → Lean 변환

--- a/docs/docs_Examples.md
+++ b/docs/docs_Examples.md
@@ -51,7 +51,7 @@
 
 ```bash
 # JSON 변환
-catprism parse --json examples/Example2.cat
+catprism parse --input examples/Example2.cat --output examples/Example2.cat.ast.json
 
 # Lean 변환
 catprism export-lean --input examples/Example2.cat

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,8 +37,8 @@ cargo build --release
 ## 3 · `.cat` → JSON (AST for Web)
 
 ```bash
-./target/release/catprism parse --json ../examples/Projection1.cat
-# → examples/Projection1.ast.json
+./target/release/catprism parse --input ../examples/Projection1.cat --output ../examples/Projection1.cat.ast.json
+# → examples/Projection1.cat.ast.json
 ```
 
 ---
@@ -89,7 +89,7 @@ python -m http.server 9000
 
 ```bash
 # 1. place MyFunctor.cat under examples/
-catprism parse --json examples/MyFunctor.cat
+catprism parse --input examples/MyFunctor.cat --output examples/MyFunctor.cat.ast.json
 catprism export-lean --input examples/MyFunctor.cat
 cd core/lean && lake build
 ```
@@ -100,7 +100,7 @@ cd core/lean && lake build
 
 | 목적             | 명령                                           |
 | -------------- | -------------------------------------------- |
-| JSON AST       | `catprism parse --json foo.cat`              |
+| JSON AST       | `catprism parse --input foo.cat --output foo.cat.ast.json` |
 | Lean export    | `catprism export-lean --input foo.cat`       |
 | Build proofs   | `lake build` (in `core/lean`)                |
 | Local web demo | `python -m http.server 9000` (in `renderer`) |

--- a/release_notes_v_0_1.md
+++ b/release_notes_v_0_1.md
@@ -7,7 +7,7 @@
 ## 🌈 Highlights
 
 - **Core DSL** — `.cat` grammar for categories, functors, custom metrics (`Δθ | Δlen | Δzero`) and ε‑composition rule.
-- **Rust Parser + CLI** — `catprism` binary: `parse --json`, `export-lean`, full AST (JSON) output.
+- **Rust Parser + CLI** — `catprism` binary: `parse --input foo.cat --output foo.cat.ast.json`, `export-lean`, full AST (JSON) output.
 - **Lean Proof Engine** — `verify_comp` tactic, `derive_phase` meta‑tactic, `PhaseDist` & `LengthDist` metrics, `HasLength` framework.
 - **Web Renderer** — Mermaid graph + WebGL beams with ε‑hue encoding; drop‑in `renderCatPrism` ESM module.
 - **CI Pipeline** — GitHub Actions: Rust build/tests → `.cat` → `.lean` export → Lean proofs + fmt checks.
@@ -39,7 +39,7 @@ examples/Projection1.cat / .ast.json + Example2~4.cat
 Run:
 
 ```bash
-catprism parse --json examples/Projection1.cat
+catprism parse --input examples/Projection1.cat --output examples/Projection1.cat.ast.json
 catprism export-lean --input examples/Projection1.cat
 lake build          # inside core/lean
 ```


### PR DESCRIPTION
## Summary
- update docs to use `--input`/`--output` rather than `--json`
- tweak release notes CLI bullet

## Testing
- `cargo test` in `parser`
- `lake build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6857760fe8ac832da34a0c5c53eb290f